### PR TITLE
docs: add GitHub links to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
+  "homepage": "https://midival.github.io/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/midival/core.git"
+  },
   "exports": {
     ".": "./dist/index.js",
     "./mpe": "./dist/mpe.js"


### PR DESCRIPTION
These will be visible on the npm package page. Partially addresses #14.